### PR TITLE
Tfs metrics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via an issue in order to avoid spending an unnecessary time writing a feature that will not be merged.
+
+## Pull Request Process
+
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a build.
+2. Update the README.md as well as other markdown documents with details of changes to the interface or architecture, this includes new configuration variables, useful file locations etc.
+3. The Pull Request requires an approved code review before it will be merged in.
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,0 +1,5 @@
+This file contains a list of people who have contributed to 
+TFServingCache.
+
+Mads Kalør <mads@kaloer.com>
+AlexMihalev

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -2,4 +2,4 @@ This file contains a list of people who have contributed to
 TFServingCache.
 
 Mads Kalør <mads@kaloer.com>
-AlexMihalev
+Alex Mihalev <alexmihalev@gmail.com>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ In order to identify which TF Serving service that should provide a model, TF Se
 | `proxyGrpcPort`                                | int         |               | gRPC port for the proxy service                                      |
 | `cacheRestPort`                                | int         |               | HTTP port for the cache service                                      |
 | `cacheGrpcPort`                                | int         |               | gRPC port for the cache service                                      |
-| `metrics.metricsPath`                          | string      |               | URL path where metrics are exposed                                   |
+| `metrics.path`                                 | string      |               | URL path where metrics are exposed                                   |
+| `metrics.timeout`                              | int         |               | Timeout (in second) for gathering metrics from TF Serving            |
 | `metrics.modelLabels`                          | bool        |               | Whether to expose model names and versions as metric labels          |
 | `modelProvider.type`                           | string      |               | The model provider service, either `diskProvider` or `s3Provider`    |
 | `modelProvider.diskProvider.basePath`          | string      |               | The path to the disk model provider                                  |
@@ -42,7 +43,7 @@ In order to identify which TF Serving service that should provide a model, TF Se
 | `serving.maxConcurrentModels`                  | int         |               | The number of models to be serving simultaneously                    |
 | `serving.grpcConfigTimeout`                    | int         |               | gRPC config timeout in seconds                                       |
 | `serving.grpcPredictTimeout`                   | int         |               | gRPC prediction timeout in seconds                                   |
-| `serving.metricsPath`                          | string      |               | Path to TF Serving metrics                                           |
+| `serving.metricsPath`                          | string      | `metrics.path`| Path to TF Serving metrics                                           |
 | `proxy.replicasPerModel`                       | int         |               | The number of nodes that should serve each model                     |
 | `proxy.grpcTimeout`                            | int         |               | Timeout for the gRPC proxy                                           |
 | `serviceDiscovery.type`                        | string      |               | The service discovery type to use. Either `consul`, `etcd`, or `k8s` |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,43 @@ When a model is requested, TF Serving Cache will identify a TF Serving service t
 
 In order to identify which TF Serving service that should provide a model, TF Serving Cache employs consistent hashing with a user-defined number of replicas per model. The number of TF Serving services available can be scaled dynamically, and either etcd or Consul are supported for service discovery.
 
+## Configs
+
+| Variable                                       | Type        | Default value | Description                                                          |
+| ---------------------------------------------- | ----------- | ------------- | -------------------------------------------------------------------- |
+| `proxyRestPort`                                | int         |               | HTTP port for the proxy service                                      |
+| `proxyGrpcPort`                                | int         |               | gRPC port for the proxy service                                      |
+| `cacheRestPort`                                | int         |               | HTTP port for the cache service                                      |
+| `cacheGrpcPort`                                | int         |               | gRPC port for the cache service                                      |
+| `metrics.metricsPath`                          | string      |               | URL path where metrics are exposed                                   |
+| `metrics.modelLabels`                          | bool        |               | Whether to expose model names and versions as metric labels          |
+| `modelProvider.type`                           | string      |               | The model provider service, either `diskProvider` or `s3Provider`    |
+| `modelProvider.diskProvider.basePath`          | string      |               | The path to the disk model provider                                  |
+| `modelProvider.s3.bucket`                      | string      |               | The S3 bucket for the model provider                                 |
+| `modelProvider.s3.basePath`                    | string      |               | Prefix for S3 keys                                                   |
+| `modelCache.hostModelPath`                     | string      |               | The directory path specifying where the cached models are stored     |
+| `modelCache.size`                              | int         |               | The size of the cache in bytes                                       |
+| `serving.servingModelPath`                     | string      |               | The directory path where models are stored in TF Serving             |
+| `serving.grpcHost`                             | string      |               | The gRPC host for TF Serving, e.g. `localhost:8500`                  |
+| `serving.restHost`                             | string      |               | The REST host for TF Serving, e.g. `http://localhost:8501`           |
+| `serving.maxConcurrentModels`                  | int         |               | The number of models to be serving simultaneously                    |
+| `serving.grpcConfigTimeout`                    | int         |               | gRPC config timeout in seconds                                       |
+| `serving.grpcPredictTimeout`                   | int         |               | gRPC prediction timeout in seconds                                   |
+| `serving.metricsPath`                          | string      |               | Path to TF Serving metrics                                           |
+| `proxy.replicasPerModel`                       | int         |               | The number of nodes that should serve each model                     |
+| `proxy.grpcTimeout`                            | int         |               | Timeout for the gRPC proxy                                           |
+| `serviceDiscovery.type`                        | string      |               | The service discovery type to use. Either `consul`, `etcd`, or `k8s` |
+| `serviceDiscovery.consul.serviceName`          | string      |               | The name to identify the TFServingCache service                      |
+| `serviceDiscovery.consul.serviceId`            | string      |               | The service id to identify the TFServingCache service                |
+| `serviceDiscovery.etcd.serviceName`            | string      |               | The service id to identify the TFServingCache service                |
+| `serviceDiscovery.etcd.endpoints`              | string list |               | The endpoints for the etcd service                                   |
+| `serviceDiscovery.etcd.allowLocalhost`         | bool        |               | Whether to allow localhost IPs for nodes                             |
+| `serviceDiscovery.etcd.authorization.username` | string      |               | etcd username                                                        |
+| `serviceDiscovery.etcd.authorization.password` | string      |               | etcd password                                                        |
+| `serviceDiscovery.k8s.fieldSelector`           | dict        |               | The fieldselector to identify TFServingCache services                |
+| `serviceDiscovery.k8s.portNames.grpcCache`     | string      |               | The name of the gRPC port of the cache                               |
+| `serviceDiscovery.k8s.portNames.httpCache`     | string      |               | The name of the HTTP port of the cache                               |
+
 ## Todos
 
 - REST (proxy):

--- a/cmd/taskhandler/main.go
+++ b/cmd/taskhandler/main.go
@@ -52,12 +52,17 @@ func serveProxy() {
 
 	var (
 		restPort = viper.GetInt("proxyRestPort")
-		restHost = viper.GetString("serving.restHost")
 		grpcPort = viper.GetInt("proxyGrpcPort")
+
+		servingRestHost = viper.GetString("serving.restHost")
 
 		metricsPath    = viper.GetString("metrics.path")
 		metricsTimeout = viper.GetInt("metrics.timeout")
 	)
+
+	if viper.IsSet("serving.metricsPath") {
+		metricsPath = viper.GetString("serving.metricsPath")
+	}
 
 	proxyMux := http.NewServeMux()
 
@@ -82,7 +87,7 @@ func serveProxy() {
 		log.Info("Proxy is disabled")
 	}
 
-	proxyMux.Handle(metricsPath, taskhandler.MetricsHandler(restHost, metricsPath, metricsTimeout))
+	proxyMux.Handle(metricsPath, taskhandler.MetricsHandler(servingRestHost, metricsPath, metricsTimeout))
 
 	log.Infof("Metrics is available at %v:%v", restPort, metricsPath)
 

--- a/cmd/taskhandler/main.go
+++ b/cmd/taskhandler/main.go
@@ -131,7 +131,7 @@ func CreateModelProvider() cachemanager.ModelProvider {
 	switch viper.GetString("modelProvider.type") {
 	case "diskProvider":
 		mProvider = diskmodelprovider.DiskModelProvider{
-			BaseDir: viper.GetString("modelProvider.baseDir"),
+			BaseDir: viper.GetString("modelProvider.diskProvider.baseDir"),
 		}
 	case "s3Provider":
 		mProvider, err = s3modelprovider.NewS3ModelProvider(

--- a/cmd/taskhandler/main.go
+++ b/cmd/taskhandler/main.go
@@ -58,10 +58,12 @@ func serveProxy() {
 
 		metricsPath    = viper.GetString("metrics.path")
 		metricsTimeout = viper.GetInt("metrics.timeout")
+
+		servingMetricsPath = metricsPath
 	)
 
 	if viper.IsSet("serving.metricsPath") {
-		metricsPath = viper.GetString("serving.metricsPath")
+		servingMetricsPath = viper.GetString("serving.metricsPath")
 	}
 
 	proxyMux := http.NewServeMux()
@@ -87,7 +89,7 @@ func serveProxy() {
 		log.Info("Proxy is disabled")
 	}
 
-	proxyMux.Handle(metricsPath, taskhandler.MetricsHandler(servingRestHost, metricsPath, metricsTimeout))
+	proxyMux.Handle(metricsPath, taskhandler.MetricsHandler(servingRestHost, servingMetricsPath, metricsTimeout))
 
 	log.Infof("Metrics is available at %v:%v", restPort, metricsPath)
 

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,11 @@ cacheRestPort: 8094
 cacheGrpcPort: 8095
 
 metrics:
-  metricsPath: "/monitoring/prometheus/metrics"
+  # this path used to publish metrics from proxy endpoint 
+  # and the same path is used to obtain metrics from serving 
+  path: "/monitoring/prometheus/metrics"
+  # timeout in seconds
+  timeout: 3 
   # Whether to add model name and version as prometheus labels
   modelLabels: false
 
@@ -29,13 +33,12 @@ serving:
   maxConcurrentModels: 2
   grpcConfigTimeout: 10 # timeout in seconds
   grpcPredictTimeout: 60
-  metricsPath: "/monitoring/prometheus/metrics"
 
 proxy:
   replicasPerModel: 3
   grpcTimeout: 10
 
-serviceDiscovery:
+  serviceDiscovery:
   #### CONSUL ####
   #type: consul
   #heartbeatTTL: 5

--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,8 @@ metrics:
 
 modelProvider:
   type: diskProvider
-  baseDir: "./model_repo"
+  diskProvider:
+    baseDir: "./model_repo"
 #modelProvider:
 #  type: s3Provider
 #  s3:

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,11 @@ cacheRestPort: 8094
 cacheGrpcPort: 8095
 
 metrics:
-  metricsPath: "/monitoring/prometheus/metrics"
+  # this path used to publish metrics from proxy endpoint 
+  # and the same path is used to obtain metrics from serving 
+  path: "/monitoring/prometheus/metrics"
+  # timeout in seconds
+  timeout: 3 
   # Whether to add model name and version as prometheus labels
   modelLabels: false
 
@@ -28,13 +32,12 @@ serving:
   maxConcurrentModels: 2
   grpcConfigTimeout: 10 # timeout in seconds
   grpcPredictTimeout: 60
-  metricsPath: "/monitoring/prometheus/metrics"
 
 proxy:
   replicasPerModel: 3
   grpcTimeout: 10
 
-serviceDiscovery:
+  serviceDiscovery:
   #### CONSUL ####
   #type: consul
   #heartbeatTTL: 5

--- a/config.yaml
+++ b/config.yaml
@@ -33,12 +33,14 @@ serving:
   maxConcurrentModels: 2
   grpcConfigTimeout: 10 # timeout in seconds
   grpcPredictTimeout: 60
+  # the TFServing Prometheus metrics path, if not specified, the metrics.path will be used
+  # metricsPath : "/monitoring/prometheus/metrics"
 
 proxy:
   replicasPerModel: 3
   grpcTimeout: 10
 
-  serviceDiscovery:
+serviceDiscovery:
   #### CONSUL ####
   #type: consul
   #heartbeatTTL: 5

--- a/deploy/docker-compose/docker-compose.yaml
+++ b/deploy/docker-compose/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
       - -c
       - > 
         echo 'model_config_list {}' > /models/models.config \
-        && echo 'prometheus_config { enable: true, path: "/monitoring/prometheus/metrics" }' > /models/monitoring.config
+        && echo 'prometheus_config { enable: true, path: "/monitoring/prometheus/metrics" }' > /models/monitoring.config \
         && /usr/bin/tensorflow_model_server \
           --port=8500 \
           --rest_api_port=8501 \

--- a/deploy/docker-compose/docker-compose.yaml
+++ b/deploy/docker-compose/docker-compose.yaml
@@ -9,8 +9,9 @@ services:
         context: ./../..
         dockerfile: deploy/docker/Dockerfile
     ports:
-      - "8094:8094"
-      - "8095:8095"
+      - "8093:8093" # http metrics
+      - "8094:8094" # http cache 
+      - "8095:8095" # grpc cache
     volumes:
       - model_cache:/model_cache
       - ${MODEL_REPO:-./model_repo}:/model_repo
@@ -26,7 +27,14 @@ services:
     entrypoint:
       - /bin/bash
       - -c
-      - echo 'model_config_list {}' > /models/models.config && /usr/bin/tensorflow_model_server --port=8500 --rest_api_port=8501 --model_config_file=/models/models.config
+      - > 
+        echo 'model_config_list {}' > /models/models.config \
+        && echo 'prometheus_config { enable: true, path: "/monitoring/prometheus/metrics" }' > /models/monitoring.config
+        && /usr/bin/tensorflow_model_server \
+          --port=8500 \
+          --rest_api_port=8501 \
+          --model_config_file=/models/models.config \
+          --monitoring_config_file='/models/monitoring.config'
     ports:
       - "8500"
       - "8501"

--- a/deploy/docker-compose/readme.md
+++ b/deploy/docker-compose/readme.md
@@ -11,12 +11,12 @@ Here's a small instruction on how to run TFservingCache with Docker:
 ```bash
 $ git clone https://github.com/tensorflow/serving
 # Location of demo models
-$ MODEL_REPO="$(pwd)/serving/tensorflow_serving/servables/tensorflow/testdata"
+$ export MODEL_REPO="$(pwd)/serving/tensorflow_serving/servables/tensorflow/testdata"
 ```
 - then TFServing with the cache attached to it can be started like so:
 ```bash
 $ cd <TFServingCache repostory folder>/deploy/docker-compose
-$ docker-copose up --build
+$ docker-compose up --build
 # the models will be consumed from MODEL_REPO assigned in the above step
 # the --build flag will force build the cache docker image from sources
 ```
@@ -40,6 +40,12 @@ $ curl http://localhost:8094/v1/models/saved_model_half_plus_two_cpu/versions/00
 $ curl -d '{"instances": [1.0, 2.0, 5.0]}' -X POST http://localhost:8094/v1/models/saved_model_half_plus_two_cpu/versions/00000123:predict
 # Returns => 
 # { "predictions": [2.5, 3.0, 4.5] }
+
+$ curl http://localhost:8093/monitoring/prometheus/metrics
+# Returns => 
+# # TYPE :tensorflow:cc:saved_model:load_attempt_count counter
+# :tensorflow:cc:saved_model:load_attempt_count{model_path="/model_cache/saved_model_half_plus_two_cpu/123",status="success"} 1
+# ...
 ```
 
 # TODO

--- a/deploy/docker/config.yaml
+++ b/deploy/docker/config.yaml
@@ -4,7 +4,12 @@ cacheRestPort: 8094
 cacheGrpcPort: 8095
 
 metrics:
-  metricsPath: "/monitoring/prometheus/metrics"
+  # this path used to publish metrics from proxy endpoint 
+  # and the same path is used to obtain metrics from serving 
+  path: "/monitoring/prometheus/metrics"
+  # timeout in seconds
+  timeout: 3 
+  # Whether to add model name and version as prometheus labels
   modelLabels: false
 
 modelProvider:
@@ -22,4 +27,3 @@ serving:
   maxConcurrentModels: 2
   grpcConfigTimeout: 10 # timeout in seconds
   grpcPredictTimeout: 60
-  metricsPath: "/monitoring/prometheus/metrics"

--- a/deploy/docker/config.yaml
+++ b/deploy/docker/config.yaml
@@ -9,7 +9,8 @@ metrics:
 
 modelProvider:
   type: diskProvider
-  baseDir: "/model_repo"
+  diskProvider:
+    baseDir: "/model_repo"
 
 modelCache:
   hostModelPath: "/model_cache"

--- a/deploy/docker/config.yaml
+++ b/deploy/docker/config.yaml
@@ -4,7 +4,12 @@ cacheRestPort: 8094
 cacheGrpcPort: 8095
 
 metrics:
-  metricsPath: "/monitoring/prometheus/metrics"
+  # this path used to publish metrics from proxy endpoint 
+  # and the same path is used to obtain metrics from serving 
+  path: "/monitoring/prometheus/metrics"
+  # timeout in seconds
+  timeout: 3 
+  # Whether to add model name and version as prometheus labels
   modelLabels: false
 
 modelProvider:

--- a/deploy/helm/readme.md
+++ b/deploy/helm/readme.md
@@ -1,0 +1,70 @@
+# Helm chart authoring
+
+## Debugging and testing
+First of all, build the docker image from source with the repository root folder as the working directory
+
+```bash
+$ docker build . -f deploy/docker/Dockerfile -t tfservingcache:latest
+# Successfully built b40bbe9181a5
+# Successfully tagged latest:latest
+```
+
+Let's use **'tfcluster'** as release name
+Test helm chart
+```bash
+# for linting
+$ helm lint deploy/helm/tfservingcache
+# ...
+# 1 chart(s) linted, 0 chart(s) failed
+
+# for dry run
+$ helm install tfcluster deploy/helm/tfservingcache --dry-run --debug
+# will print rendered chart 
+```
+Install helm chart
+```bash
+# initial installation
+$ helm install tfcluster deploy/helm/tfservingcache
+# or upgrade
+$ helm upgrade tfcluster deploy/helm/tfservingcache --install
+```
+Run curl in temporary pod 
+```bash
+# for interactive session
+$ kubectl run --generator=run-pod/v1 curl --image=radial/busyboxplus:curl -i --tty --rm
+# or to run curl command once
+$ kubectl run --generator=run-pod/v1 curl --image=radial/busyboxplus:curl -i --tty --rm -- \
+curl http://tfserving-tfservingcache:8094/v1/models/saved_model_half_plus_two_cpu/versions/00000123
+```
+Use node port service type
+```bash
+$ helm upgrade tfserving . --install \
+--set models.provider.hostPath.path=/run/desktop/mnt/host/wsl/models \
+--set service.type=NodePort \
+--set logLevel=debug
+
+# get service to obtain host 
+$ kubectl get service -l app.kubernetes.io/instance=tfserving
+# NAME                       TYPE       CLUSTER-IP     EXTERNAL-IP   PORT(S)                                                       AGE
+# tfserving-tfservingcache   NodePort   10.106.18.87   <none>        8093:31230/TCP,8100:32460/TCP,8094:32767/TCP,8095:31991/TCP   12m
+```
+
+## Host Path Volume (WSL2)
+The Kubernetes Volumes not correctly mounted with WSL2 (windows), here posible workaround 
+Mount dirrectory with models
+```bash 
+mkdir /mnt/wsl/models
+sudo mount --bind <path where models actualy located> /mnt/wsl/models
+```
+Pass mounted folder to kubernetes with `/run/desktop/mnt/host/wsl/` like so:
+```bash 
+helm install tfserving . --set models.provider.hostPath.path=/run/desktop/mnt/host/wsl/models
+```
+> Please read [Kubernetes Volumes not correctly mounted with WSL2](https://github.com/docker/for-win/issues/5325)
+
+## TODO
+- add liveness and readiness probes both for TFServing and TFServingCache
+- add ingress rules (looks like the latest Nginx based ingress controller support both HTTP and GRPC)
+- add support for Prometheus Operator
+  - metrics from TFServing should be gathered also
+  - build Grafana dashboard to show additional latency and resources consumption (will be very useful for future load testing and profiling )

--- a/deploy/helm/readme.md
+++ b/deploy/helm/readme.md
@@ -38,15 +38,15 @@ curl http://tfserving-tfservingcache:8094/v1/models/saved_model_half_plus_two_cp
 ```
 Use node port service type
 ```bash
-$ helm upgrade tfserving . --install \
+$ helm upgrade tfcluster deploy/helm/tfservingcache --install \
 --set models.provider.hostPath.path=/run/desktop/mnt/host/wsl/models \
 --set service.type=NodePort \
 --set logLevel=debug
 
 # get service to obtain host 
-$ kubectl get service -l app.kubernetes.io/instance=tfserving
+$ kubectl get service -l app.kubernetes.io/instance=tfcluster
 # NAME                       TYPE       CLUSTER-IP     EXTERNAL-IP   PORT(S)                                                       AGE
-# tfserving-tfservingcache   NodePort   10.106.18.87   <none>        8093:31230/TCP,8100:32460/TCP,8094:32767/TCP,8095:31991/TCP   12m
+# tfcluster-tfservingcache   NodePort   10.106.18.87   <none>        8093:31230/TCP,8100:32460/TCP,8094:32767/TCP,8095:31991/TCP   12m
 ```
 
 ## Host Path Volume (WSL2)

--- a/deploy/helm/tfservingcache/.helmignore
+++ b/deploy/helm/tfservingcache/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/tfservingcache/Chart.yaml
+++ b/deploy/helm/tfservingcache/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "1.0"
+description: A Helm chart for TF Serving Cache
+name: tfservingcache
+version: 0.1.0

--- a/deploy/helm/tfservingcache/templates/NOTES.txt
+++ b/deploy/helm/tfservingcache/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. The list of deployed PODs can be obtained like os:
+kubectl get pods -l "app.kubernetes.io/name={{ include "tfservingcache.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
+
+2. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "tfservingcache.fullname" . }}-proxy)
+  export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods -l "app.kubernetes.io/name={{ include "tfservingcache.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 or grpc://127.0.0.1:8081 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.cache.ports.proxyHttp }} 8081:{{ .Values.cache.ports.proxyGrpc }}
+{{- end }}
+
+3. Please be patient, the readiness probe is not implemented yet.

--- a/deploy/helm/tfservingcache/templates/_helpers.tpl
+++ b/deploy/helm/tfservingcache/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tfservingcache.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tfservingcache.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tfservingcache.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tfservingcache.labels" -}}
+helm.sh/chart: {{ include "tfservingcache.chart" . }}
+{{ include "tfservingcache.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tfservingcache.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tfservingcache.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deploy/helm/tfservingcache/templates/cache-config.yaml
+++ b/deploy/helm/tfservingcache/templates/cache-config.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tfservingcache.fullname" . }}
+  labels:
+    {{- include "tfservingcache.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- if .Values.logLevel }}
+    logLevel: {{ .Values.logLevel }}
+    {{- end }}
+    
+    proxyRestPort: {{ .Values.cache.ports.proxyHttp }}
+    proxyGrpcPort: {{ .Values.cache.ports.proxyGrpc }}
+    cacheRestPort: {{ .Values.cache.ports.cacheHttp }}
+    cacheGrpcPort: {{ .Values.cache.ports.cacheGrpc }}
+
+    metrics:
+      metricsPath: "/monitoring/prometheus/metrics"
+      modelLabels: false
+
+    modelProvider:
+    {{- with .Values.models.provider.hostPath }}
+      type: diskProvider
+      baseDir: {{ .mount }}
+    {{- end }}
+    {{- with .Values.models.provider.s3 }}
+      type: s3Provider
+      s3:
+        bucket: {{ .bucket }}
+        basePath: {{ .path }}
+    {{- end }}
+
+    modelCache:
+      hostModelPath: {{ .Values.models.cache.path }}
+      size: {{ .Values.models.cache.size }}
+
+    serving:
+      servingModelPath: {{ .Values.models.cache.path }}
+      grpcHost: "localhost:{{ .Values.serving.ports.grpc }}"
+      restHost: "http://localhost:{{ .Values.serving.ports.http }}"
+      maxConcurrentModels: 2
+      grpcConfigTimeout: 10 
+      grpcPredictTimeout: 60
+      metricsPath: "/monitoring/prometheus/metrics"    
+
+    serviceDiscovery:
+      type: k8s
+      k8s:
+        fieldSelector:
+          metadata.name: {{ include "tfservingcache.fullname" . }}-cache
+        portNames:
+          grpcCache: grpc-cache
+          httpCache: http-cache
+

--- a/deploy/helm/tfservingcache/templates/cache-config.yaml
+++ b/deploy/helm/tfservingcache/templates/cache-config.yaml
@@ -16,7 +16,8 @@ data:
     cacheGrpcPort: {{ .Values.cache.ports.cacheGrpc }}
 
     metrics:
-      metricsPath: "/monitoring/prometheus/metrics"
+      path: "/monitoring/prometheus/metrics"
+      timeout: 3
       modelLabels: false
 
     modelProvider:
@@ -43,7 +44,6 @@ data:
       maxConcurrentModels: 2
       grpcConfigTimeout: 10 
       grpcPredictTimeout: 60
-      metricsPath: "/monitoring/prometheus/metrics"    
 
     serviceDiscovery:
       type: k8s

--- a/deploy/helm/tfservingcache/templates/cache-config.yaml
+++ b/deploy/helm/tfservingcache/templates/cache-config.yaml
@@ -9,7 +9,7 @@ data:
     {{- if .Values.logLevel }}
     logLevel: {{ .Values.logLevel }}
     {{- end }}
-    
+
     proxyRestPort: {{ .Values.cache.ports.proxyHttp }}
     proxyGrpcPort: {{ .Values.cache.ports.proxyGrpc }}
     cacheRestPort: {{ .Values.cache.ports.cacheHttp }}
@@ -22,7 +22,8 @@ data:
     modelProvider:
     {{- with .Values.models.provider.hostPath }}
       type: diskProvider
-      baseDir: {{ .mount }}
+      diskProvider:
+        baseDir: {{ .mount }}
     {{- end }}
     {{- with .Values.models.provider.s3 }}
       type: s3Provider
@@ -52,4 +53,3 @@ data:
         portNames:
           grpcCache: grpc-cache
           httpCache: http-cache
-

--- a/deploy/helm/tfservingcache/templates/cache-service.yaml
+++ b/deploy/helm/tfservingcache/templates/cache-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tfservingcache.fullname" . }}-cache
+  labels:
+    {{- include "tfservingcache.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.cache.ports.cacheHttp }}
+      protocol: TCP
+      name: http-cache
+    - port: {{ .Values.cache.ports.cacheGrpc }}
+      protocol: TCP
+      name: grpc-cache
+  selector:
+    {{- include "tfservingcache.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/tfservingcache/templates/deployment.yaml
+++ b/deploy/helm/tfservingcache/templates/deployment.yaml
@@ -53,7 +53,14 @@ spec:
           command:
             - /bin/bash
             - -c
-            - echo 'model_config_list {}' > /models/models.config && /usr/bin/tensorflow_model_server --port={{ .Values.serving.ports.grpc }} --rest_api_port={{ .Values.serving.ports.http }} --model_config_file=/models/models.config
+            - >
+              echo 'model_config_list {}' > /models/models.config \
+              && echo 'prometheus_config { enable: true, path: "/monitoring/prometheus/metrics" }' > /models/monitoring.config \
+              && /usr/bin/tensorflow_model_server \
+                --port={{ .Values.serving.ports.grpc }} \
+                --rest_api_port={{ .Values.serving.ports.http }} \
+                --model_config_file=/models/models.config \
+                --monitoring_config_file=/models/monitoring.config
           volumeMounts:
             - name: cache
               mountPath: {{ .Values.models.cache.path }}

--- a/deploy/helm/tfservingcache/templates/deployment.yaml
+++ b/deploy/helm/tfservingcache/templates/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tfservingcache.fullname" . }}
+  labels:
+    {{- include "tfservingcache.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tfservingcache.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "tfservingcache.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: "cache"
+          image: "{{ .Values.cache.image.repository }}:{{ .Values.cache.image.tag }}"
+          imagePullPolicy: {{ .Values.cache.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.cache.ports.proxyHttp }}
+              name: http-proxy
+            - containerPort: {{ .Values.cache.ports.proxyGrpc }}
+              name: grpc-proxy
+            - containerPort: {{ .Values.cache.ports.cacheHttp }}
+              name: http-cache
+            - containerPort: {{ .Values.cache.ports.cacheGrpc }}
+              name: grpc-cache
+          volumeMounts:
+            - name: cache-config
+              mountPath: /tfservingcache/config.yaml
+              subPath: config.yaml
+          {{- with .Values.models.provider.hostPath }}              
+            - name: models
+              mountPath: {{ .mount }}
+          {{- end }}
+            - name: cache
+              mountPath: {{ .Values.models.cache.path }}
+          resources:
+            {{- toYaml .Values.cache.resources | nindent 12 }}
+        - name: "serving"
+          image: "{{ .Values.serving.image.repository }}:{{ .Values.serving.image.tag }}"
+          imagePullPolicy: {{ .Values.serving.image.pullPolicy }}
+          command:
+            - /bin/bash
+            - -c
+            - echo 'model_config_list {}' > /models/models.config && /usr/bin/tensorflow_model_server --port={{ .Values.serving.ports.grpc }} --rest_api_port={{ .Values.serving.ports.http }} --model_config_file=/models/models.config
+          volumeMounts:
+            - name: cache
+              mountPath: {{ .Values.models.cache.path }}
+          resources:
+            {{- toYaml .Values.serving.resources | nindent 12 }}
+      volumes:
+        - name: cache-config
+          configMap:
+            name: {{ include "tfservingcache.fullname" . }}
+        - name: cache
+          emptyDir: {}
+      {{- with .Values.models.provider.hostPath }}
+        - name: models
+          hostPath:
+            path: {{ .path }}
+            type: Directory
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/tfservingcache/templates/proxy-service.yaml
+++ b/deploy/helm/tfservingcache/templates/proxy-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tfservingcache.fullname" . }}-proxy
+  labels:
+    {{- include "tfservingcache.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.ports.http }}
+      targetPort: {{ .Values.cache.ports.proxyHttp }}
+      protocol: TCP
+      name: http-proxy
+    - port:  {{ .Values.service.ports.grpc }}
+      targetPort: {{ .Values.cache.ports.proxyGrpc }}
+      protocol: TCP
+      name: grpc-proxy
+  selector:
+    {{- include "tfservingcache.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/tfservingcache/values.yaml
+++ b/deploy/helm/tfservingcache/values.yaml
@@ -1,0 +1,55 @@
+# Default values for tfservingcache.
+nameOverride: ""
+fullnameOverride: ""
+
+cache:
+  image:
+    repository: tfservingcache
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources: {}
+  ports:
+    proxyHttp: 8093
+    proxyGrpc: 8100
+    cacheHttp: 8094
+    cacheGrpc: 8095
+
+serving:
+  image:
+    repository: tensorflow/serving
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources: {}
+  ports:
+    http: 8501
+    grpc: 8500
+
+service:
+  type: ClusterIP
+  ports:
+    http: 8501
+    grpc: 8500
+
+models:
+  provider:
+    hostPath: 
+      path: /run/desktop/mnt/host/wsl/models
+      mount: /model_repo
+#   s3: 
+#     bucket: foo
+#     path: models/foo/bar
+  cache:
+    size: 30000
+    path: /model_cache
+
+replicaCount: 2
+
+imagePullSecrets: []
+
+podAnnotations: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -1,0 +1,37 @@
+metrics:
+  metricsPath: "/monitoring/prometheus/metrics"
+  # Whether to add model name and version as prometheus labels
+  modelLabels: false
+
+modelProvider:
+  type: diskProvider
+  diskProvider:
+    baseDir: "./model_repo"
+
+modelCache:
+  hostModelPath: "./models"
+  size: 30000
+
+serving:
+  servingModelPath: "/models"
+  grpcHost: "localhost:8500"
+  restHost: "http://localhost:8501"
+  maxConcurrentModels: 2
+  grpcConfigTimeout: 10 # timeout in seconds
+  grpcPredictTimeout: 60
+  metricsPath: "/monitoring/prometheus/metrics"
+
+proxy:
+  replicasPerModel: 3
+  grpcTimeout: 10
+
+serviceDiscovery:
+  type: etcd
+  heartbeatTTL: 5
+  etcd:
+    serviceName: tfservingcache
+    endpoints: ["localhost:2379"]
+    allowLocalhost: true
+    authorization:
+      username: root
+      password: foobar

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/hashicorp/consul/api v1.3.0
 	github.com/otiai10/copy v1.0.2
 	github.com/prometheus/client_golang v1.5.0
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.9.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.6.1
 	github.com/tensorflow/tensorflow/tensorflow/go/core v0.0.0-00010101000000-000000000000

--- a/pkg/taskhandler/metrics.go
+++ b/pkg/taskhandler/metrics.go
@@ -1,0 +1,53 @@
+package taskhandler
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/expfmt"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// MetricsHandler returns an http.Handler
+func MetricsHandler(metricsHost string, metricsPath string, timeout int) http.Handler {
+
+	target, _ := url.Parse(metricsHost)
+	target.Path = metricsPath
+
+	gatherers := prometheus.Gatherers{
+		prometheus.DefaultGatherer,
+		prometheus.GathererFunc(func() ([]*dto.MetricFamily, error) {
+
+			// assuming that tfserving always returns metrics in plain text format,
+			// otherwise, we can enforce a suitable format through Accept header
+			httpClient := http.Client{Timeout: time.Second * time.Duration(timeout)}
+
+			resp, err := httpClient.Get(target.String())
+			if err != nil {
+				return nil, err
+			}
+
+			var parser expfmt.TextParser
+
+			parsed, err := parser.TextToMetricFamilies(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+
+			var result []*dto.MetricFamily
+			for _, mf := range parsed {
+				result = append(result, mf)
+			}
+
+			return result, nil
+		}),
+	}
+
+	return promhttp.InstrumentMetricHandler(
+		prometheus.DefaultRegisterer, promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{}),
+	)
+}

--- a/pkg/taskhandler/metrics_test.go
+++ b/pkg/taskhandler/metrics_test.go
@@ -1,0 +1,60 @@
+package taskhandler
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+func TestMetricsHandler(t *testing.T) {
+
+	var (
+		path           = "/metrics"
+		servingCounter = ":tensorflow:core:counter"
+		cacheCounter   = "tfservingcache_counter"
+	)
+
+	promauto.NewCounter(prometheus.CounterOpts{
+		Name: cacheCounter,
+	}).Inc()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if path != r.URL.Path {
+			t.Error("expected", path, "got", r.URL.Path)
+		}
+
+		fmt.Fprintf(w, "# TYPE %v counter\n%v 42\n", servingCounter, servingCounter)
+	}))
+	defer ts.Close()
+
+	handler := MetricsHandler(ts.URL, path, 42)
+
+	req, err := http.NewRequest("GET", path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	if http.StatusOK != res.Code {
+		t.Error("expected", http.StatusOK, "got", res.Code)
+	}
+
+	body := res.Body.String()
+
+	if !strings.Contains(body, servingCounter) {
+		t.Error("The response does not contain 'serving' metrics")
+	}
+
+	if !strings.Contains(body, cacheCounter) {
+		t.Error("The response does not contain 'cache' metrics")
+	}
+}


### PR DESCRIPTION
I would like to propose to **merge** metrics from **tfserving** and **tfservingcache** into one endpoint because:
- although Prometheus Operator supports many metrics endpoints in one pod, bat Prometheus itself and, for example, Datadog use pod annotations for metrics endpoints discovery, that's makes it impossible to specify separate endpoints for cache and serving
- as I understand, **tfserving** does not support a health check RPC (see https://github.com/tensorflow/serving/issues/671), so metrics can play this role, at least for now. Having 'merged' metrics will test not only serving availability but also connectivity between them (at least for HTTP).