### PR TITLE
Add config documentation and refactor modelProvider config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via an issue in order to avoid spending an unnecessary time writing a feature that will not be merged.
+
+## Pull Request Process
+
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a build.
+2. Update the README.md as well as other markdown documents with details of changes to the interface or architecture, this includes new configuration variables, useful file locations etc.
+3. The Pull Request requires an approved code review before it will be merged in.
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,0 +1,5 @@
+This file contains a list of people who have contributed to 
+TFServingCache.
+
+Mads Kalør <mads@kaloer.com>
+AlexMihalev

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ In order to identify which TF Serving service that should provide a model, TF Se
 | `metrics.metricsPath`                          | string      |               | URL path where metrics are exposed                                   |
 | `metrics.modelLabels`                          | bool        |               | Whether to expose model names and versions as metric labels          |
 | `modelProvider.type`                           | string      |               | The model provider service, either `diskProvider` or `s3Provider`    |
+| `modelProvider.diskProvider.basePath`          | string      |               | The path to the disk model provider                                  |
+| `modelProvider.s3.bucket`                      | string      |               | The S3 bucket for the model provider                                 |
+| `modelProvider.s3.basePath`                    | string      |               | Prefix for S3 keys                                                   |
 | `modelCache.hostModelPath`                     | string      |               | The directory path specifying where the cached models are stored     |
 | `modelCache.size`                              | int         |               | The size of the cache in bytes                                       |
 | `serving.servingModelPath`                     | string      |               | The directory path where models are stored in TF Serving             |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,40 @@ When a model is requested, TF Serving Cache will identify a TF Serving service t
 
 In order to identify which TF Serving service that should provide a model, TF Serving Cache employs consistent hashing with a user-defined number of replicas per model. The number of TF Serving services available can be scaled dynamically, and either etcd or Consul are supported for service discovery.
 
+## Configs
+
+| Variable                                       | Type        | Default value | Description                                                          |
+| ---------------------------------------------- | ----------- | ------------- | -------------------------------------------------------------------- |
+| `proxyRestPort`                                | int         |               | HTTP port for the proxy service                                      |
+| `proxyGrpcPort`                                | int         |               | gRPC port for the proxy service                                      |
+| `cacheRestPort`                                | int         |               | HTTP port for the cache service                                      |
+| `cacheGrpcPort`                                | int         |               | gRPC port for the cache service                                      |
+| `metrics.metricsPath`                          | string      |               | URL path where metrics are exposed                                   |
+| `metrics.modelLabels`                          | bool        |               | Whether to expose model names and versions as metric labels          |
+| `modelProvider.type`                           | string      |               | The model provider service, either `diskProvider` or `s3Provider`    |
+| `modelCache.hostModelPath`                     | string      |               | The directory path specifying where the cached models are stored     |
+| `modelCache.size`                              | int         |               | The size of the cache in bytes                                       |
+| `serving.servingModelPath`                     | string      |               | The directory path where models are stored in TF Serving             |
+| `serving.grpcHost`                             | string      |               | The gRPC host for TF Serving, e.g. `localhost:8500`                  |
+| `serving.restHost`                             | string      |               | The REST host for TF Serving, e.g. `http://localhost:8501`           |
+| `serving.maxConcurrentModels`                  | int         |               | The number of models to be serving simultaneously                    |
+| `serving.grpcConfigTimeout`                    | int         |               | gRPC config timeout in seconds                                       |
+| `serving.grpcPredictTimeout`                   | int         |               | gRPC prediction timeout in seconds                                   |
+| `serving.metricsPath`                          | string      |               | Path to TF Serving metrics                                           |
+| `proxy.replicasPerModel`                       | int         |               | The number of nodes that should serve each model                     |
+| `proxy.grpcTimeout`                            | int         |               | Timeout for the gRPC proxy                                           |
+| `serviceDiscovery.type`                        | string      |               | The service discovery type to use. Either `consul`, `etcd`, or `k8s` |
+| `serviceDiscovery.consul.serviceName`          | string      |               | The name to identify the TFServingCache service                      |
+| `serviceDiscovery.consul.serviceId`            | string      |               | The service id to identify the TFServingCache service                |
+| `serviceDiscovery.etcd.serviceName`            | string      |               | The service id to identify the TFServingCache service                |
+| `serviceDiscovery.etcd.endpoints`              | string list |               | The endpoints for the etcd service                                   |
+| `serviceDiscovery.etcd.allowLocalhost`         | bool        |               | Whether to allow localhost IPs for nodes                             |
+| `serviceDiscovery.etcd.authorization.username` | string      |               | etcd username                                                        |
+| `serviceDiscovery.etcd.authorization.password` | string      |               | etcd password                                                        |
+| `serviceDiscovery.k8s.fieldSelector`           | dict        |               | The fieldselector to identify TFServingCache services                |
+| `serviceDiscovery.k8s.portNames.grpcCache`     | string      |               | The name of the gRPC port of the cache                               |
+| `serviceDiscovery.k8s.portNames.httpCache`     | string      |               | The name of the HTTP port of the cache                               |
+
 ## Todos
 
 - REST (proxy):

--- a/cmd/taskhandler/main.go
+++ b/cmd/taskhandler/main.go
@@ -131,7 +131,7 @@ func CreateModelProvider() cachemanager.ModelProvider {
 	switch viper.GetString("modelProvider.type") {
 	case "diskProvider":
 		mProvider = diskmodelprovider.DiskModelProvider{
-			BaseDir: viper.GetString("modelProvider.baseDir"),
+			BaseDir: viper.GetString("modelProvider.diskProvider.baseDir"),
 		}
 	case "s3Provider":
 		mProvider, err = s3modelprovider.NewS3ModelProvider(

--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,8 @@ metrics:
 
 modelProvider:
   type: diskProvider
-  baseDir: "./model_repo"
+  diskProvider:
+    baseDir: "./model_repo"
 #modelProvider:
 #  type: s3Provider
 #  s3:

--- a/deploy/docker/config.yaml
+++ b/deploy/docker/config.yaml
@@ -9,7 +9,8 @@ metrics:
 
 modelProvider:
   type: diskProvider
-  baseDir: "/model_repo"
+  diskProvider:
+    baseDir: "/model_repo"
 
 modelCache:
   hostModelPath: "/model_cache"

--- a/deploy/helm/tfservingcache/templates/cache-config.yaml
+++ b/deploy/helm/tfservingcache/templates/cache-config.yaml
@@ -9,7 +9,7 @@ data:
     {{- if .Values.logLevel }}
     logLevel: {{ .Values.logLevel }}
     {{- end }}
-    
+
     proxyRestPort: {{ .Values.cache.ports.proxyHttp }}
     proxyGrpcPort: {{ .Values.cache.ports.proxyGrpc }}
     cacheRestPort: {{ .Values.cache.ports.cacheHttp }}
@@ -22,7 +22,8 @@ data:
     modelProvider:
     {{- with .Values.models.provider.hostPath }}
       type: diskProvider
-      baseDir: {{ .mount }}
+      diskProvider:
+        baseDir: {{ .mount }}
     {{- end }}
     {{- with .Values.models.provider.s3 }}
       type: s3Provider
@@ -52,4 +53,3 @@ data:
         portNames:
           grpcCache: grpc-cache
           httpCache: http-cache
-

--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -1,0 +1,37 @@
+metrics:
+  metricsPath: "/monitoring/prometheus/metrics"
+  # Whether to add model name and version as prometheus labels
+  modelLabels: false
+
+modelProvider:
+  type: diskProvider
+  diskProvider:
+    baseDir: "./model_repo"
+
+modelCache:
+  hostModelPath: "./models"
+  size: 30000
+
+serving:
+  servingModelPath: "/models"
+  grpcHost: "localhost:8500"
+  restHost: "http://localhost:8501"
+  maxConcurrentModels: 2
+  grpcConfigTimeout: 10 # timeout in seconds
+  grpcPredictTimeout: 60
+  metricsPath: "/monitoring/prometheus/metrics"
+
+proxy:
+  replicasPerModel: 3
+  grpcTimeout: 10
+
+serviceDiscovery:
+  type: etcd
+  heartbeatTTL: 5
+  etcd:
+    serviceName: tfservingcache
+    endpoints: ["localhost:2379"]
+    allowLocalhost: true
+    authorization:
+      username: root
+      password: foobar


### PR DESCRIPTION
Adds documentation of the configuration options. This also refactors the `modelProvider` config such that the `diskProvider`  type has its own sub-config to explicitly show which settings belong to that type.