### PR TITLE
Add health check probes through gRPC

### DIFF
--- a/cmd/taskhandler/main.go
+++ b/cmd/taskhandler/main.go
@@ -32,15 +32,12 @@ func main() {
 		defer taskHandler.Close()
 	}
 	for {
-		log.Info("Cache is healthy: ", cache.IsHealthy())
 		isHealthy := cache.IsHealthy()
-
 		cache.GrpcProxy.SetHealth(isHealthy)
 		if taskHandler != nil {
 			taskHandler.GrpcProxy.SetHealth(isHealthy)
 		}
-
-		time.Sleep(time.Second * 5)
+		time.Sleep(time.Second * 30)
 	}
 }
 

--- a/cmd/taskhandler/main.go
+++ b/cmd/taskhandler/main.go
@@ -31,6 +31,7 @@ func main() {
 	if taskHandler != nil {
 		defer taskHandler.Close()
 	}
+	// Run health checks
 	for {
 		isHealthy := cache.IsHealthy()
 		cache.GrpcProxy.SetHealth(isHealthy)

--- a/deploy/helm/tfservingcache/templates/deployment.yaml
+++ b/deploy/helm/tfservingcache/templates/deployment.yaml
@@ -36,19 +36,38 @@ spec:
               name: http-cache
             - containerPort: {{ .Values.cache.ports.cacheGrpc }}
               name: grpc-cache
+          livenessProbe:
+            grpc:
+              port: {{ .Values.cache.ports.proxyGrpc }}
+            initialDelaySeconds: 10
+            timeoutSeconds: 60
+            periodSeconds: 60
+          startupProbe:
+            grpc:
+              port: {{ .Values.cache.ports.proxyGrpc }}
+            periodSeconds: 30
+            timeoutSeconds: 60
+          readinessProbe:
+            grpc:
+              port: {{ .Values.cache.ports.proxyGrpc }}
+            timeoutSeconds: 60
+            initialDelaySeconds: 5
           volumeMounts:
             - name: cache-config
               mountPath: /tfservingcache/config.yaml
               subPath: config.yaml
-          {{- with .Values.models.provider.hostPath }}              
+          {{- with .Values.models.provider.hostPath }}
+          {{- if .mount }}              
             - name: models
               mountPath: {{ .mount }}
+           {{- end }}   
           {{- end }}
             - name: cache
               mountPath: {{ .Values.models.cache.path }}
           resources:
             {{- toYaml .Values.cache.resources | nindent 12 }}
           env:
+          {{- if .Values.models.provider.azBlob }}
           {{- with .Values.models.provider.azBlob.secretKeyRef }}
             {{- if .containerKey }}
             - name: TFSC_MODELPROVIDER_AZBLOB_CONTAINER
@@ -78,6 +97,7 @@ spec:
                   name: {{ .secretName }}
                   key: {{ .accountKeyKey }}
             {{- end }}
+          {{- end }}
           {{- end }}
         - name: "serving"
           image: "{{ .Values.serving.image.repository }}:{{ .Values.serving.image.tag }}"

--- a/pkg/cachemanager/cachemanager.go
+++ b/pkg/cachemanager/cachemanager.go
@@ -82,6 +82,7 @@ func (cache *CacheManager) IsHealthy() bool {
 			return false
 		}
 	}
+	// Check if model provider is healthy
 	modelProviderIsHealthy := cache.ModelProvider.Check()
 	return modelProviderIsHealthy
 }

--- a/pkg/cachemanager/modelprovider.go
+++ b/pkg/cachemanager/modelprovider.go
@@ -3,4 +3,5 @@ package cachemanager
 type ModelProvider interface {
 	LoadModel(modelName string, modelVersion int64, destinationDir string) (*Model, error)
 	ModelSize(modelName string, modelVersion int64) (int64, error)
+	Check() bool
 }

--- a/pkg/cachemanager/modelproviders/azblobmodelprovider/azblobmodelprovider.go
+++ b/pkg/cachemanager/modelproviders/azblobmodelprovider/azblobmodelprovider.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-blob-go/azblob"
@@ -168,4 +169,17 @@ func (provider AZBlobModelProvider) getKeyForModel(modelName string, modelVersio
 	return AZBlobLocation{
 		KeyPrefix: fmt.Sprintf("%s%s/%d/", modelPrefix, modelName, modelVersion),
 	}
+}
+
+func (provider AZBlobModelProvider) Check() bool {
+	containerURL := azblob.NewContainerURL(*provider.ContainerURL, provider.pipeline)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	marker := azblob.Marker{}
+	_, err := containerURL.ListBlobsFlatSegment(ctx, marker, azblob.ListBlobsSegmentOptions{MaxResults: 1})
+	if err != nil {
+		log.WithError(err).Errorf("Could not list blobs")
+		return false
+	}
+	return true
 }

--- a/pkg/cachemanager/modelproviders/azblobmodelprovider/azblobmodelprovider.go
+++ b/pkg/cachemanager/modelproviders/azblobmodelprovider/azblobmodelprovider.go
@@ -172,6 +172,7 @@ func (provider AZBlobModelProvider) getKeyForModel(modelName string, modelVersio
 }
 
 func (provider AZBlobModelProvider) Check() bool {
+	// Call list blob resource to check blob health
 	containerURL := azblob.NewContainerURL(*provider.ContainerURL, provider.pipeline)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/pkg/cachemanager/modelproviders/diskmodelprovider/diskmodelprovider.go
+++ b/pkg/cachemanager/modelproviders/diskmodelprovider/diskmodelprovider.go
@@ -81,3 +81,7 @@ func (provider DiskModelProvider) ModelSize(modelName string, modelVersion int64
 	size := fi.Size()
 	return size, nil
 }
+
+func (provider DiskModelProvider) Check() bool {
+	return true
+}

--- a/pkg/cachemanager/modelproviders/diskmodelprovider/diskmodelprovider.go
+++ b/pkg/cachemanager/modelproviders/diskmodelprovider/diskmodelprovider.go
@@ -83,5 +83,6 @@ func (provider DiskModelProvider) ModelSize(modelName string, modelVersion int64
 }
 
 func (provider DiskModelProvider) Check() bool {
+	// Assume that disk is always healthy
 	return true
 }

--- a/pkg/cachemanager/modelproviders/s3modelprovider/s3modelprovider.go
+++ b/pkg/cachemanager/modelproviders/s3modelprovider/s3modelprovider.go
@@ -168,3 +168,13 @@ func (provider S3ModelProvider) getKeyForModel(modelName string, modelVersion in
 		KeyPrefix: fmt.Sprintf("%s%s/%d/", modelPrefix, modelName, modelVersion),
 	}
 }
+
+func (provider S3ModelProvider) Check() bool {
+	maxKeys := int64(1)
+	_, err := provider.s3.ListObjectsV2(&s3.ListObjectsV2Input{Bucket: &provider.Bucket, MaxKeys: &maxKeys})
+	if err != nil {
+		log.WithError(err).Errorf("Error accessing model on S3. Bucket: %s", provider.Bucket)
+		return false
+	}
+	return true
+}

--- a/pkg/cachemanager/modelproviders/s3modelprovider/s3modelprovider.go
+++ b/pkg/cachemanager/modelproviders/s3modelprovider/s3modelprovider.go
@@ -170,6 +170,7 @@ func (provider S3ModelProvider) getKeyForModel(modelName string, modelVersion in
 }
 
 func (provider S3ModelProvider) Check() bool {
+	// Call list blob resource to check blob health
 	maxKeys := int64(1)
 	_, err := provider.s3.ListObjectsV2(&s3.ListObjectsV2Input{Bucket: &provider.Bucket, MaxKeys: &maxKeys})
 	if err != nil {


### PR DESCRIPTION
Add health checks exposed through gRPC

This pull request adds health checks. The health checks are exposed through gRPC and include liveness, startup, and readiness probes. These checks ensure that the serving cache is running correctly and ready to serve requests.

The changes made in this pull request are as follows:
- Added liveness, startup, and readiness probes to the cache container in deployment.yaml
- Exposed the health checks through gRPC

This change improves the reliability and stability of the cache container, ensuring that it is always available to serve requests. 