### PR TITLE
Supress health logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TF Serving Cache
 
-TF Serving load balancer/model cache that dynamically loads and unloads models into TensorFlow Serving services on demand. 
+TF Serving load balancer/model cache that dynamically loads and unloads models into TensorFlow Serving services on demand.
 
 [An article about the project can be found here.](https://medium.com/p/d3c4bb959d56)
 
@@ -24,46 +24,47 @@ In order to identify which TF Serving service that should provide a model, TF Se
 
 ## Configs
 
-| Variable                                       | Type        | Default value  | Description                                                                          |
-| ---------------------------------------------- | ----------- | -------------- | ------------------------------------------------------------------------------------ |
-| `proxyRestPort`                                | int         |                | HTTP port for the proxy service                                                      |
-| `proxyGrpcPort`                                | int         |                | gRPC port for the proxy service                                                      |
-| `cacheRestPort`                                | int         |                | HTTP port for the cache service                                                      |
-| `cacheGrpcPort`                                | int         |                | gRPC port for the cache service                                                      |
-| `metrics.path`                                 | string      |                | URL path where metrics are exposed                                                   |
-| `metrics.timeout`                              | int         |                | Timeout (in second) for gathering metrics from TF Serving                            |
-| `metrics.modelLabels`                          | bool        |                | Whether to expose model names and versions as metric labels                          |
-| `modelProvider.type`                           | string      |                | The model provider service, either `diskProvider`, `s3Provider` or `azBlobProvider`  |
-| `modelProvider.diskProvider.basePath`          | string      |                | The path to the disk model provider                                                  |
-| `modelProvider.s3.bucket`                      | string      |                | The S3 bucket for the model provider                                                 |
-| `modelProvider.s3.basePath`                    | string      |                | Prefix for S3 keys                                                                   |
-| `modelProvider.azBlob.container`               | string      |                | The Azure storage container containing the models                                    |
-| `modelProvider.azBlob.containerUrl`            | string      |                | The Azure storage container url (an alternative to `modelProvider.azBlob.container`) |
-| `modelProvider.azBlob.basePath`                | string      |                | The model prefix for Azure blob keys                                                 |
-| `modelProvider.azBlob.accountName`             | string      |                | The Azure storage account name                                                       |
-| `modelProvider.azBlob.accountKey`              | string      |                | The Azure storage account access key                                                 |
-| `modelCache.hostModelPath`                     | string      |                | The directory path specifying where the cached models are stored                     |
-| `modelCache.size`                              | int         |                | The size of the cache in bytes                                                       |
-| `serving.servingModelPath`                     | string      |                | The directory path where models are stored in TF Serving                             |
-| `serving.grpcHost`                             | string      |                | The gRPC host for TF Serving, e.g. `localhost:8500`                                  |
-| `serving.restHost`                             | string      |                | The REST host for TF Serving, e.g. `http://localhost:8501`                           |
-| `serving.maxConcurrentModels`                  | int         |                | The number of models to be serving simultaneously                                    |
-| `serving.grpcConfigTimeout`                    | int         |                | gRPC config timeout in seconds                                                       |
-| `serving.grpcPredictTimeout`                   | int         |                | gRPC prediction timeout in seconds                                                   |
-| `serving.metricsPath`                          | string      | `metrics.path` | Path to TF Serving metrics                                                           |
-| `proxy.replicasPerModel`                       | int         |                | The number of nodes that should serve each model                                     |
-| `proxy.grpcTimeout`                            | int         |                | Timeout for the gRPC proxy                                                           |
-| `serviceDiscovery.type`                        | string      |                | The service discovery type to use. Either `consul`, `etcd`, or `k8s`                 |
-| `serviceDiscovery.consul.serviceName`          | string      |                | The name to identify the TFServingCache service                                      |
-| `serviceDiscovery.consul.serviceId`            | string      |                | The service id to identify the TFServingCache service                                |
-| `serviceDiscovery.etcd.serviceName`            | string      |                | The service id to identify the TFServingCache service                                |
-| `serviceDiscovery.etcd.endpoints`              | string list |                | The endpoints for the etcd service                                                   |
-| `serviceDiscovery.etcd.allowLocalhost`         | bool        |                | Whether to allow localhost IPs for nodes                                             |
-| `serviceDiscovery.etcd.authorization.username` | string      |                | etcd username                                                                        |
-| `serviceDiscovery.etcd.authorization.password` | string      |                | etcd password                                                                        |
-| `serviceDiscovery.k8s.fieldSelector`           | dict        |                | The fieldselector to identify TFServingCache services                                |
-| `serviceDiscovery.k8s.portNames.grpcCache`     | string      |                | The name of the gRPC port of the cache                                               |
-| `serviceDiscovery.k8s.portNames.httpCache`     | string      |                | The name of the HTTP port of the cache                                               |
+| Variable                                       | Type        | Default value                    | Description                                                                          |
+| ---------------------------------------------- | ----------- | -------------------------------- | ------------------------------------------------------------------------------------ |
+| `proxyRestPort`                                | int         |                                  | HTTP port for the proxy service                                                      |
+| `proxyGrpcPort`                                | int         |                                  | gRPC port for the proxy service                                                      |
+| `cacheRestPort`                                | int         |                                  | HTTP port for the cache service                                                      |
+| `cacheGrpcPort`                                | int         |                                  | gRPC port for the cache service                                                      |
+| `metrics.path`                                 | string      |                                  | URL path where metrics are exposed                                                   |
+| `metrics.timeout`                              | int         |                                  | Timeout (in second) for gathering metrics from TF Serving                            |
+| `metrics.modelLabels`                          | bool        |                                  | Whether to expose model names and versions as metric labels                          |
+| `modelProvider.type`                           | string      |                                  | The model provider service, either `diskProvider`, `s3Provider` or `azBlobProvider`  |
+| `modelProvider.diskProvider.basePath`          | string      |                                  | The path to the disk model provider                                                  |
+| `modelProvider.s3.bucket`                      | string      |                                  | The S3 bucket for the model provider                                                 |
+| `modelProvider.s3.basePath`                    | string      |                                  | Prefix for S3 keys                                                                   |
+| `modelProvider.azBlob.container`               | string      |                                  | The Azure storage container containing the models                                    |
+| `modelProvider.azBlob.containerUrl`            | string      |                                  | The Azure storage container url (an alternative to `modelProvider.azBlob.container`) |
+| `modelProvider.azBlob.basePath`                | string      |                                  | The model prefix for Azure blob keys                                                 |
+| `modelProvider.azBlob.accountName`             | string      |                                  | The Azure storage account name                                                       |
+| `modelProvider.azBlob.accountKey`              | string      |                                  | The Azure storage account access key                                                 |
+| `modelCache.hostModelPath`                     | string      |                                  | The directory path specifying where the cached models are stored                     |
+| `modelCache.size`                              | int         |                                  | The size of the cache in bytes                                                       |
+| `serving.servingModelPath`                     | string      |                                  | The directory path where models are stored in TF Serving                             |
+| `serving.grpcHost`                             | string      |                                  | The gRPC host for TF Serving, e.g. `localhost:8500`                                  |
+| `serving.restHost`                             | string      |                                  | The REST host for TF Serving, e.g. `http://localhost:8501`                           |
+| `serving.maxConcurrentModels`                  | int         |                                  | The number of models to be serving simultaneously                                    |
+| `serving.grpcConfigTimeout`                    | int         |                                  | gRPC config timeout in seconds                                                       |
+| `serving.grpcPredictTimeout`                   | int         |                                  | gRPC prediction timeout in seconds                                                   |
+| `serving.metricsPath`                          | string      | `metrics.path`                   | Path to TF Serving metrics                                                           |
+| `proxy.replicasPerModel`                       | int         |                                  | The number of nodes that should serve each model                                     |
+| `proxy.grpcTimeout`                            | int         |                                  | Timeout for the gRPC proxy                                                           |
+| `serviceDiscovery.type`                        | string      |                                  | The service discovery type to use. Either `consul`, `etcd`, or `k8s`                 |
+| `serviceDiscovery.consul.serviceName`          | string      |                                  | The name to identify the TFServingCache service                                      |
+| `serviceDiscovery.consul.serviceId`            | string      |                                  | The service id to identify the TFServingCache service                                |
+| `serviceDiscovery.etcd.serviceName`            | string      |                                  | The service id to identify the TFServingCache service                                |
+| `serviceDiscovery.etcd.endpoints`              | string list |                                  | The endpoints for the etcd service                                                   |
+| `serviceDiscovery.etcd.allowLocalhost`         | bool        |                                  | Whether to allow localhost IPs for nodes                                             |
+| `serviceDiscovery.etcd.authorization.username` | string      |                                  | etcd username                                                                        |
+| `serviceDiscovery.etcd.authorization.password` | string      |                                  | etcd password                                                                        |
+| `serviceDiscovery.k8s.fieldSelector`           | dict        |                                  | The fieldselector to identify TFServingCache services                                |
+| `serviceDiscovery.k8s.portNames.grpcCache`     | string      |                                  | The name of the gRPC port of the cache                                               |
+| `serviceDiscovery.k8s.portNames.httpCache`     | string      |                                  | The name of the HTTP port of the cache                                               |
+| `healthProbe.modelName`                        | string      | `__TFSERVINGCACHE_PROBE_CHECK__` | The name of the model to use for health probes                                       |
 
 ## Todos
 

--- a/cmd/taskhandler/cfg.go
+++ b/cmd/taskhandler/cfg.go
@@ -11,6 +11,7 @@ func SetConfig() {
 	viper.SetConfigName("config")
 	viper.AddConfigPath(".")
 	viper.SetConfigType("yaml")
+	setDefaults()
 	viper.SetEnvPrefix("tfsc")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
@@ -47,4 +48,8 @@ func SetConfig() {
 		log.SetLevel(log.InfoLevel)
 	}
 
+}
+
+func setDefaults() {
+	viper.SetDefault("healthprobe.modelName", "__TFSERVINGCACHE_PROBE_CHECK__")
 }

--- a/deploy/helm/tfservingcache/templates/NOTES.txt
+++ b/deploy/helm/tfservingcache/templates/NOTES.txt
@@ -11,5 +11,3 @@ kubectl get pods -l "app.kubernetes.io/name={{ include "tfservingcache.name" . }
   echo "Visit http://127.0.0.1:8080 or grpc://127.0.0.1:8081 to use your application"
   kubectl port-forward $POD_NAME 8080:{{ .Values.cache.ports.proxyHttp }} 8081:{{ .Values.cache.ports.proxyGrpc }}
 {{- end }}
-
-3. Please be patient, the readiness probe is not implemented yet.

--- a/deploy/helm/tfservingcache/templates/deployment.yaml
+++ b/deploy/helm/tfservingcache/templates/deployment.yaml
@@ -99,6 +99,8 @@ spec:
             {{- end }}
           {{- end }}
           {{- end }}
+            - name: TFSC_HEALTHPROBE_MODELNAME
+              value: {{ .Values.healthProbe.modelName }}
         - name: "serving"
           image: "{{ .Values.serving.image.repository }}:{{ .Values.serving.image.tag }}"
           imagePullPolicy: {{ .Values.serving.image.pullPolicy }}

--- a/deploy/helm/tfservingcache/values.yaml
+++ b/deploy/helm/tfservingcache/values.yaml
@@ -44,6 +44,9 @@ models:
     path: /model_cache
   replicasPerModel: 2
 
+healthProbe:
+  modelName: __TFSERVINGCACHE_PROBE_CHECK__
+
 replicaCount: 2
 
 imagePullSecrets: []


### PR DESCRIPTION
- Suppressed health check logs when retrieving model status for the health probe model.
- Added `healthProbe.modelName` param to helm chart params
- Updated `README.md`