### PR TITLE
Evict stale gRPC connections, retry across replicas, and add graceful shutdown

### DIFF
--- a/cmd/taskhandler/main.go
+++ b/cmd/taskhandler/main.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/mKaloer/TFServingCache/pkg/cachemanager"
@@ -21,28 +25,64 @@ func main() {
 
 	SetConfig()
 
-	cache := serveCache()
-	defer cache.GrpcProxy.Close()
+	cache, cacheHTTPServer := serveCache()
 
-	taskHandler, err := serveProxy()
+	taskHandler, proxyHTTPServer, err := serveProxy()
 	if err != nil {
 		log.WithError(err).Fatal("Could not start proxy")
 	}
-	if taskHandler != nil {
-		defer taskHandler.Close()
-	}
-	// Run health checks
+
+	// Wait for shutdown signal
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGTERM, syscall.SIGINT)
+
+	// Run health checks until shutdown signal
+	healthTicker := time.NewTicker(30 * time.Second)
+	defer healthTicker.Stop()
+
 	for {
-		isHealthy := cache.IsHealthy()
-		cache.GrpcProxy.SetHealth(isHealthy)
-		if taskHandler != nil {
-			taskHandler.GrpcProxy.SetHealth(isHealthy)
+		select {
+		case <-healthTicker.C:
+			isHealthy := cache.IsHealthy()
+			cache.GrpcProxy.SetHealth(isHealthy)
+			if taskHandler != nil {
+				taskHandler.GrpcProxy.SetHealth(isHealthy)
+			}
+		case sig := <-stop:
+			log.Infof("Received signal %v, shutting down gracefully...", sig)
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			// Mark as unhealthy so k8s stops routing traffic
+			cache.GrpcProxy.SetHealth(false)
+			if taskHandler != nil {
+				taskHandler.GrpcProxy.SetHealth(false)
+			}
+
+			if taskHandler != nil {
+				if err := taskHandler.Close(); err != nil {
+					log.WithError(err).Error("Error closing task handler")
+				}
+			}
+			if err := cache.GrpcProxy.Close(); err != nil {
+				log.WithError(err).Error("Error closing cache gRPC proxy")
+			}
+			if proxyHTTPServer != nil {
+				if err := proxyHTTPServer.Shutdown(shutdownCtx); err != nil {
+					log.WithError(err).Error("Error shutting down proxy HTTP server")
+				}
+			}
+			if err := cacheHTTPServer.Shutdown(shutdownCtx); err != nil {
+				log.WithError(err).Error("Error shutting down cache HTTP server")
+			}
+
+			log.Info("Shutdown complete")
+			return
 		}
-		time.Sleep(time.Second * 30)
 	}
 }
 
-func serveCache() *cachemanager.CacheManager {
+func serveCache() (*cachemanager.CacheManager, *http.Server) {
 
 	var (
 		restPort = viper.GetInt("cacheRestPort")
@@ -56,14 +96,19 @@ func serveCache() *cachemanager.CacheManager {
 	cacheMux := http.NewServeMux()
 
 	cacheMux.HandleFunc("/v1/models/", cache.ServeRest())
-	go http.ListenAndServe(fmt.Sprintf(":%d", restPort), cacheMux)
+	cacheHTTPServer := &http.Server{Addr: fmt.Sprintf(":%d", restPort), Handler: cacheMux}
+	go func() {
+		if err := cacheHTTPServer.ListenAndServe(); err != http.ErrServerClosed {
+			log.WithError(err).Fatal("Cache HTTP server error")
+		}
+	}()
 
 	go cache.GrpcProxy.Listen(grpcPort)
 
-	return cache
+	return cache, cacheHTTPServer
 }
 
-func serveProxy() (*taskhandler.TaskHandler, error) {
+func serveProxy() (*taskhandler.TaskHandler, *http.Server, error) {
 
 	var (
 		restPort = viper.GetInt("proxyRestPort")
@@ -91,7 +136,7 @@ func serveProxy() (*taskhandler.TaskHandler, error) {
 		err := tHandler.ConnectToCluster()
 		if err != nil {
 			log.WithError(err).Fatal("Could not connect to cluster")
-			return nil, err
+			return nil, nil, err
 		}
 
 		go tHandler.GrpcProxy.Listen(grpcPort)
@@ -108,8 +153,13 @@ func serveProxy() (*taskhandler.TaskHandler, error) {
 
 	log.Infof("Metrics are available at %v:%v", restPort, metricsPath)
 
-	go http.ListenAndServe(fmt.Sprintf(":%d", restPort), proxyMux)
-	return tHandler, nil
+	proxyHTTPServer := &http.Server{Addr: fmt.Sprintf(":%d", restPort), Handler: proxyMux}
+	go func() {
+		if err := proxyHTTPServer.ListenAndServe(); err != http.ErrServerClosed {
+			log.WithError(err).Fatal("Proxy HTTP server error")
+		}
+	}()
+	return tHandler, proxyHTTPServer, nil
 }
 
 func CreateCacheManager() *cachemanager.CacheManager {

--- a/cmd/taskhandler/main.go
+++ b/cmd/taskhandler/main.go
@@ -59,6 +59,9 @@ func main() {
 				taskHandler.GrpcProxy.SetHealth(false)
 			}
 
+			// Allow k8s to propagate the unhealthy status before closing connections
+			time.Sleep(5 * time.Second)
+
 			if taskHandler != nil {
 				if err := taskHandler.Close(); err != nil {
 					log.WithError(err).Error("Error closing task handler")
@@ -103,7 +106,11 @@ func serveCache() (*cachemanager.CacheManager, *http.Server) {
 		}
 	}()
 
-	go cache.GrpcProxy.Listen(grpcPort)
+	go func() {
+		if err := cache.GrpcProxy.Listen(grpcPort); err != nil {
+			log.WithError(err).Fatal("Cache gRPC server error")
+		}
+	}()
 
 	return cache, cacheHTTPServer
 }
@@ -139,7 +146,11 @@ func serveProxy() (*taskhandler.TaskHandler, *http.Server, error) {
 			return nil, nil, err
 		}
 
-		go tHandler.GrpcProxy.Listen(grpcPort)
+		go func() {
+			if err := tHandler.GrpcProxy.Listen(grpcPort); err != nil {
+				log.WithError(err).Fatal("Proxy gRPC server error")
+			}
+		}()
 
 		proxyMux.HandleFunc("/v1/models/", tHandler.ServeRest())
 

--- a/pkg/cachemanager/cachemanager.go
+++ b/pkg/cachemanager/cachemanager.go
@@ -282,13 +282,13 @@ func (cache *CacheManager) restDirector(req *http.Request, modelName string, ver
 	return nil
 }
 
-func (cache *CacheManager) grpcDirector(modelName string, version string) (*grpc.ClientConn, error) {
+func (cache *CacheManager) grpcDirector(modelName string, version string) ([]*grpc.ClientConn, error) {
 	err := cache.handleModelRequest(modelName, version)
 	if err != nil {
 		log.WithError(err).Errorf("Error handling request")
 		return nil, err
 	}
-	return cache.localGrpcConnection, nil
+	return []*grpc.ClientConn{cache.localGrpcConnection}, nil
 }
 
 func (cache *CacheManager) handleModelRequest(modelName string, version string) error {

--- a/pkg/taskhandler/taskhandler.go
+++ b/pkg/taskhandler/taskhandler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/connectivity"
 )
 
 // TaskHandler handles TFServing jobs. A TaskHandler is
@@ -80,24 +81,24 @@ func (handler *TaskHandler) DisconnectFromCluster() error {
 	return handler.Cluster.Disconnect()
 }
 
-// nodeForKey returns a node that can handle the given model
-func (handler *TaskHandler) nodeForKey(modelName string, version string) (ServingService, error) {
+// nodesForKey returns all replica nodes that can handle the given model
+func (handler *TaskHandler) nodesForKey(modelName string, version string) ([]ServingService, error) {
 	var modelKey = modelName + "##" + version
 	nodes, err := handler.Cluster.FindNodeForKey(modelKey)
 	if err != nil {
-		return ServingService{}, err
+		return nil, err
 	}
-	// Pick random node
-	return nodes[rand.Intn(len(nodes))], nil
+	return nodes, nil
 }
 
 // restDirector is the director of REST requests.
 func (handler *TaskHandler) restDirector(req *http.Request, modelName string, version string) error {
-	selectedNode, err := handler.nodeForKey(modelName, version)
+	nodes, err := handler.nodesForKey(modelName, version)
 	if err != nil {
 		log.WithError(err).Error("Error finding node for model")
 		return fmt.Errorf("Error finding node for model: %w", err)
 	}
+	selectedNode := nodes[rand.Intn(len(nodes))]
 	selectedURL, err := url.Parse(fmt.Sprintf("http://%s:%d", selectedNode.Host, selectedNode.RestPort))
 	if err != nil {
 		log.WithError(err).Error("Error parsing proxy url")
@@ -107,32 +108,68 @@ func (handler *TaskHandler) restDirector(req *http.Request, modelName string, ve
 	log.Infof("Forwarding to cache: %s", selectedURL.String())
 	req.URL = selectedURL
 	if _, ok := req.Header["User-Agent"]; !ok {
-		// explicitly disable User-Agent so it's not set to default value
 		req.Header.Set("User-Agent", "")
 	}
 	return nil
 }
 
-// grpcDirector is the director of GRPC requests.
-func (handler *TaskHandler) grpcDirector(modelName string, version string) (*grpc.ClientConn, error) {
-	selectedNode, err := handler.nodeForKey(modelName, version)
+// grpcDirector returns connections to all replica nodes for the given model.
+func (handler *TaskHandler) grpcDirector(modelName string, version string) ([]*grpc.ClientConn, error) {
+	nodes, err := handler.nodesForKey(modelName, version)
 	if err != nil {
-		log.WithError(err).Error("Error finding node")
+		log.WithError(err).Error("Error finding nodes")
 		return nil, err
 	}
-	// grpc host is idx 0, port is idx 2 after split
-	grpcHost := fmt.Sprintf("%s:%d", selectedNode.Host, selectedNode.GrpcPort)
-	log.Infof("Forwarding to cache: %s", grpcHost)
-	// Check if connection exists - otherwise create new connection
+	conns := make([]*grpc.ClientConn, 0, len(nodes))
+	for _, node := range nodes {
+		grpcHost := fmt.Sprintf("%s:%d", node.Host, node.GrpcPort)
+		conn, err := handler.getOrCreateConnection(grpcHost)
+		if err != nil {
+			log.WithError(err).Warnf("Could not get connection to %s, skipping", grpcHost)
+			continue
+		}
+		conns = append(conns, conn)
+	}
+	if len(conns) == 0 {
+		return nil, fmt.Errorf("no available connections for model %s:%s", modelName, version)
+	}
+	return conns, nil
+}
+
+// getOrCreateConnection returns a healthy cached connection or creates a new one.
+// Evicts connections in TransientFailure or Shutdown state.
+func (handler *TaskHandler) getOrCreateConnection(grpcHost string) (*grpc.ClientConn, error) {
 	handler.grpcConnections.mutex.RLock()
 	if conn, ok := handler.grpcConnections.ConnMap[grpcHost]; ok {
+		state := conn.GetState()
+		if state == connectivity.TransientFailure || state == connectivity.Shutdown {
+			handler.grpcConnections.mutex.RUnlock()
+			handler.grpcConnections.mutex.Lock()
+			defer handler.grpcConnections.mutex.Unlock()
+			// Re-check under write lock
+			if existing, ok := handler.grpcConnections.ConnMap[grpcHost]; ok && existing == conn {
+				log.Warnf("Evicting stale gRPC connection to %s (state: %s)", grpcHost, state)
+				conn.Close()
+				delete(handler.grpcConnections.ConnMap, grpcHost)
+			} else if ok {
+				return existing, nil
+			}
+			return handler.dialAndStore(grpcHost)
+		}
 		handler.grpcConnections.mutex.RUnlock()
 		return conn, nil
 	}
-	// No connection exists - swap to write lock and connect
 	handler.grpcConnections.mutex.RUnlock()
 	handler.grpcConnections.mutex.Lock()
 	defer handler.grpcConnections.mutex.Unlock()
+	// Double-check after acquiring write lock
+	if conn, ok := handler.grpcConnections.ConnMap[grpcHost]; ok {
+		return conn, nil
+	}
+	return handler.dialAndStore(grpcHost)
+}
+
+func (handler *TaskHandler) dialAndStore(grpcHost string) (*grpc.ClientConn, error) {
 	conn, err := grpc.Dial(grpcHost,
 		grpc.WithInsecure(),
 		grpc.WithTimeout(viper.GetDuration("serving.grpcPredictTimeout")*time.Second),
@@ -143,7 +180,6 @@ func (handler *TaskHandler) grpcDirector(modelName string, version string) (*grp
 		handler.grpcConnections.ConnMap[grpcHost] = conn
 	}
 	return conn, err
-
 }
 
 func (connMap *grpcConnMap) Close() error {

--- a/pkg/taskhandler/taskhandler.go
+++ b/pkg/taskhandler/taskhandler.go
@@ -98,6 +98,9 @@ func (handler *TaskHandler) restDirector(req *http.Request, modelName string, ve
 		log.WithError(err).Error("Error finding node for model")
 		return fmt.Errorf("Error finding node for model: %w", err)
 	}
+	if len(nodes) == 0 {
+		return fmt.Errorf("no available nodes for model %s:%s", modelName, version)
+	}
 	selectedNode := nodes[rand.Intn(len(nodes))]
 	selectedURL, err := url.Parse(fmt.Sprintf("http://%s:%d", selectedNode.Host, selectedNode.RestPort))
 	if err != nil {
@@ -149,10 +152,21 @@ func (handler *TaskHandler) getOrCreateConnection(grpcHost string) (*grpc.Client
 			// Re-check under write lock
 			if existing, ok := handler.grpcConnections.ConnMap[grpcHost]; ok && existing == conn {
 				log.Warnf("Evicting stale gRPC connection to %s (state: %s)", grpcHost, state)
-				conn.Close()
+				if err := conn.Close(); err != nil {
+					log.WithError(err).Warnf("Error closing stale gRPC connection to %s", grpcHost)
+				}
 				delete(handler.grpcConnections.ConnMap, grpcHost)
 			} else if ok {
-				return existing, nil
+				existState := existing.GetState()
+				if existState == connectivity.TransientFailure || existState == connectivity.Shutdown {
+					log.Warnf("Replacement connection to %s also stale (state: %s), re-dialing", grpcHost, existState)
+					if err := existing.Close(); err != nil {
+						log.WithError(err).Warnf("Error closing stale replacement connection to %s", grpcHost)
+					}
+					delete(handler.grpcConnections.ConnMap, grpcHost)
+				} else {
+					return existing, nil
+				}
 			}
 			return handler.dialAndStore(grpcHost)
 		}
@@ -176,10 +190,12 @@ func (handler *TaskHandler) dialAndStore(grpcHost string) (*grpc.ClientConn, err
 		grpc.WithConnectParams(grpc.ConnectParams{Backoff: backoff.DefaultConfig}),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(handler.maxGrpcMsgSize), grpc.MaxCallSendMsgSize(handler.maxGrpcMsgSize)),
 	)
-	if err == nil {
-		handler.grpcConnections.ConnMap[grpcHost] = conn
+	if err != nil {
+		log.WithError(err).Errorf("Failed to dial gRPC host %s", grpcHost)
+		return nil, err
 	}
-	return conn, err
+	handler.grpcConnections.ConnMap[grpcHost] = conn
+	return conn, nil
 }
 
 func (connMap *grpcConnMap) Close() error {

--- a/pkg/tfservingproxy/tfservingproxy.go
+++ b/pkg/tfservingproxy/tfservingproxy.go
@@ -19,6 +19,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var tfServingRestURLMatch = regexp.MustCompile(`(?i)^/v1/models/(?P<modelName>[^/]+)(/versions/(?P<version>[0-9]+))?`)
@@ -60,8 +62,6 @@ func NewRestProxy(handler func(req *http.Request, modelName string, version stri
 		log.Debugf("Model name: '%s' Version: '%s'", matches[1], matches[3])
 		err := handler(req, matches[1], matches[3])
 		if err != nil {
-			promRequestsFailed.WithLabelValues("rest").Inc()
-		} else {
 			promRequestsFailed.WithLabelValues("rest").Inc()
 		}
 	}
@@ -178,16 +178,21 @@ func (server *proxyServiceServer) Classify(ctx context.Context, req *pb.Classifi
 		log.WithError(err).Error("Could not get grpc client")
 		return nil, err
 	}
+	var lastErr error
 	for i, client := range clients {
 		service := pb.NewPredictionServiceClient(client)
-		res, err := service.Classify(ctx, req)
-		if err == nil {
+		res, lastErr := service.Classify(ctx, req)
+		if lastErr == nil {
 			return res, nil
 		}
-		log.WithError(err).Warnf("Classify failed on connection %d/%d", i+1, len(clients))
+		if !isRetryable(lastErr) {
+			promRequestsFailed.WithLabelValues("grpc").Inc()
+			return nil, lastErr
+		}
+		log.WithError(lastErr).Warnf("Classify failed on connection %d/%d", i+1, len(clients))
 	}
 	promRequestsFailed.WithLabelValues("grpc").Inc()
-	return nil, fmt.Errorf("all %d connections failed for Classify", len(clients))
+	return nil, fmt.Errorf("all %d connections failed for Classify: %w", len(clients), lastErr)
 }
 
 // Regress.
@@ -199,16 +204,21 @@ func (server *proxyServiceServer) Regress(ctx context.Context, req *pb.Regressio
 		promRequestsFailed.WithLabelValues("grpc").Inc()
 		return nil, err
 	}
+	var lastErr error
 	for i, client := range clients {
 		service := pb.NewPredictionServiceClient(client)
-		res, err := service.Regress(ctx, req)
-		if err == nil {
+		res, lastErr := service.Regress(ctx, req)
+		if lastErr == nil {
 			return res, nil
 		}
-		log.WithError(err).Warnf("Regress failed on connection %d/%d", i+1, len(clients))
+		if !isRetryable(lastErr) {
+			promRequestsFailed.WithLabelValues("grpc").Inc()
+			return nil, lastErr
+		}
+		log.WithError(lastErr).Warnf("Regress failed on connection %d/%d", i+1, len(clients))
 	}
 	promRequestsFailed.WithLabelValues("grpc").Inc()
-	return nil, fmt.Errorf("all %d connections failed for Regress", len(clients))
+	return nil, fmt.Errorf("all %d connections failed for Regress: %w", len(clients), lastErr)
 }
 
 // Predict -- provides access to loaded TensorFlow model.
@@ -220,16 +230,21 @@ func (server *proxyServiceServer) Predict(ctx context.Context, req *pb.PredictRe
 		promRequestsFailed.WithLabelValues("grpc").Inc()
 		return nil, err
 	}
+	var lastErr error
 	for i, client := range clients {
 		service := pb.NewPredictionServiceClient(client)
-		res, err := service.Predict(ctx, req)
-		if err == nil {
+		res, lastErr := service.Predict(ctx, req)
+		if lastErr == nil {
 			return res, nil
 		}
-		log.WithError(err).Warnf("Predict failed on connection %d/%d", i+1, len(clients))
+		if !isRetryable(lastErr) {
+			promRequestsFailed.WithLabelValues("grpc").Inc()
+			return nil, lastErr
+		}
+		log.WithError(lastErr).Warnf("Predict failed on connection %d/%d", i+1, len(clients))
 	}
 	promRequestsFailed.WithLabelValues("grpc").Inc()
-	return nil, fmt.Errorf("all %d connections failed for Predict", len(clients))
+	return nil, fmt.Errorf("all %d connections failed for Predict: %w", len(clients), lastErr)
 }
 
 // MultiInference API for multi-headed models.
@@ -246,16 +261,21 @@ func (server *proxyServiceServer) GetModelMetadata(ctx context.Context, req *pb.
 		promRequestsFailed.WithLabelValues("grpc").Inc()
 		return nil, err
 	}
+	var lastErr error
 	for i, client := range clients {
 		service := pb.NewPredictionServiceClient(client)
-		res, err := service.GetModelMetadata(ctx, req)
-		if err == nil {
+		res, lastErr := service.GetModelMetadata(ctx, req)
+		if lastErr == nil {
 			return res, nil
 		}
-		log.WithError(err).Warnf("GetModelMetadata failed on connection %d/%d", i+1, len(clients))
+		if !isRetryable(lastErr) {
+			promRequestsFailed.WithLabelValues("grpc").Inc()
+			return nil, lastErr
+		}
+		log.WithError(lastErr).Warnf("GetModelMetadata failed on connection %d/%d", i+1, len(clients))
 	}
 	promRequestsFailed.WithLabelValues("grpc").Inc()
-	return nil, fmt.Errorf("all %d connections failed for GetModelMetadata", len(clients))
+	return nil, fmt.Errorf("all %d connections failed for GetModelMetadata: %w", len(clients), lastErr)
 }
 
 func (server *proxyServiceServer) SessionRun(ctx context.Context, req *pb.SessionRunRequest) (*pb.SessionRunResponse, error) {
@@ -266,16 +286,35 @@ func (server *proxyServiceServer) SessionRun(ctx context.Context, req *pb.Sessio
 		promRequestsFailed.WithLabelValues("grpc").Inc()
 		return nil, err
 	}
+	var lastErr error
 	for i, client := range clients {
 		service := pb.NewSessionServiceClient(client)
-		res, err := service.SessionRun(ctx, req)
-		if err == nil {
+		res, lastErr := service.SessionRun(ctx, req)
+		if lastErr == nil {
 			return res, nil
 		}
-		log.WithError(err).Warnf("SessionRun failed on connection %d/%d", i+1, len(clients))
+		if !isRetryable(lastErr) {
+			promRequestsFailed.WithLabelValues("grpc").Inc()
+			return nil, lastErr
+		}
+		log.WithError(lastErr).Warnf("SessionRun failed on connection %d/%d", i+1, len(clients))
 	}
 	promRequestsFailed.WithLabelValues("grpc").Inc()
-	return nil, fmt.Errorf("all %d connections failed for SessionRun", len(clients))
+	return nil, fmt.Errorf("all %d connections failed for SessionRun: %w", len(clients), lastErr)
+}
+
+// isRetryable returns true for gRPC errors that may succeed on a different connection.
+func isRetryable(err error) bool {
+	st, ok := status.FromError(err)
+	if !ok {
+		return true // non-gRPC error, assume transient
+	}
+	switch st.Code() {
+	case codes.Unavailable, codes.Internal, codes.Unknown, codes.DeadlineExceeded:
+		return true
+	default:
+		return false
+	}
 }
 
 func (server *proxyServiceServer) clientForSpec(modelSpec *pb.ModelSpec) ([]*grpc.ClientConn, error) {

--- a/pkg/tfservingproxy/tfservingproxy.go
+++ b/pkg/tfservingproxy/tfservingproxy.go
@@ -73,7 +73,7 @@ func NewRestProxy(handler func(req *http.Request, modelName string, version stri
 }
 
 // NewGrpcProxy creates a new GrpcProxy for TF Serving
-func NewGrpcProxy(clientProvider func(modelName string, version string) (*grpc.ClientConn, error), maxGrpcMsgSize int) *GrpcProxy {
+func NewGrpcProxy(clientProvider func(modelName string, version string) ([]*grpc.ClientConn, error), maxGrpcMsgSize int) *GrpcProxy {
 	promRequestsTotal.WithLabelValues("grpc")
 	promRequestsFailed.WithLabelValues("grpc")
 
@@ -166,49 +166,70 @@ func (proxy *GrpcProxy) Close() error {
 // proxyServiceServer implements the relevant TF serving grpc methods
 // and extracts model name and version and forwards the requests to a handler node
 type proxyServiceServer struct {
-	clientProvider func(modelName string, version string) (*grpc.ClientConn, error)
+	clientProvider func(modelName string, version string) ([]*grpc.ClientConn, error)
 }
 
 // Classify.
 func (server *proxyServiceServer) Classify(ctx context.Context, req *pb.ClassificationRequest) (*pb.ClassificationResponse, error) {
 	promRequestsTotal.WithLabelValues("grpc").Inc()
-	client, err := server.clientForSpec(req.GetModelSpec())
+	clients, err := server.clientForSpec(req.GetModelSpec())
 	if err != nil {
 		promRequestsFailed.WithLabelValues("grpc").Inc()
 		log.WithError(err).Error("Could not get grpc client")
 		return nil, err
 	}
-	service := pb.NewPredictionServiceClient(client)
-	res, err := service.Classify(ctx, req)
-	return res, err
+	for i, client := range clients {
+		service := pb.NewPredictionServiceClient(client)
+		res, err := service.Classify(ctx, req)
+		if err == nil {
+			return res, nil
+		}
+		log.WithError(err).Warnf("Classify failed on connection %d/%d", i+1, len(clients))
+	}
+	promRequestsFailed.WithLabelValues("grpc").Inc()
+	return nil, fmt.Errorf("all %d connections failed for Classify", len(clients))
 }
 
 // Regress.
 func (server *proxyServiceServer) Regress(ctx context.Context, req *pb.RegressionRequest) (*pb.RegressionResponse, error) {
 	promRequestsTotal.WithLabelValues("grpc").Inc()
-	client, err := server.clientForSpec(req.GetModelSpec())
+	clients, err := server.clientForSpec(req.GetModelSpec())
 	if err != nil {
 		log.WithError(err).Error("Could not get grpc client")
 		promRequestsFailed.WithLabelValues("grpc").Inc()
 		return nil, err
 	}
-	service := pb.NewPredictionServiceClient(client)
-	res, err := service.Regress(ctx, req)
-	return res, err
+	for i, client := range clients {
+		service := pb.NewPredictionServiceClient(client)
+		res, err := service.Regress(ctx, req)
+		if err == nil {
+			return res, nil
+		}
+		log.WithError(err).Warnf("Regress failed on connection %d/%d", i+1, len(clients))
+	}
+	promRequestsFailed.WithLabelValues("grpc").Inc()
+	return nil, fmt.Errorf("all %d connections failed for Regress", len(clients))
 }
 
 // Predict -- provides access to loaded TensorFlow model.
 func (server *proxyServiceServer) Predict(ctx context.Context, req *pb.PredictRequest) (*pb.PredictResponse, error) {
 	promRequestsTotal.WithLabelValues("grpc").Inc()
-	client, err := server.clientForSpec(req.GetModelSpec())
+	clients, err := server.clientForSpec(req.GetModelSpec())
 	if err != nil {
 		log.WithError(err).Error("Could not get grpc client")
 		promRequestsFailed.WithLabelValues("grpc").Inc()
 		return nil, err
 	}
-	service := pb.NewPredictionServiceClient(client)
-	res, err := service.Predict(ctx, req)
-	return res, err
+	for i, client := range clients {
+		service := pb.NewPredictionServiceClient(client)
+		res, err := service.Predict(ctx, req)
+		if err == nil {
+			return res, nil
+		}
+		log.WithError(err).Warnf("Predict failed on connection %d/%d", i+1, len(clients))
+	}
+	promRequestsFailed.WithLabelValues("grpc").Inc()
+	return nil, fmt.Errorf("all %d connections failed for Predict", len(clients))
 }
 
 // MultiInference API for multi-headed models.
@@ -219,31 +240,45 @@ func (server *proxyServiceServer) MultiInference(ctx context.Context, req *pb.Mu
 // GetModelMetadata - provides access to metadata for loaded models.
 func (server *proxyServiceServer) GetModelMetadata(ctx context.Context, req *pb.GetModelMetadataRequest) (*pb.GetModelMetadataResponse, error) {
 	promRequestsTotal.WithLabelValues("grpc").Inc()
-	client, err := server.clientForSpec(req.GetModelSpec())
+	clients, err := server.clientForSpec(req.GetModelSpec())
 	if err != nil {
 		log.WithError(err).Error("Could not get grpc client")
 		promRequestsFailed.WithLabelValues("grpc").Inc()
 		return nil, err
 	}
-	service := pb.NewPredictionServiceClient(client)
-	res, err := service.GetModelMetadata(ctx, req)
-	return res, err
+	for i, client := range clients {
+		service := pb.NewPredictionServiceClient(client)
+		res, err := service.GetModelMetadata(ctx, req)
+		if err == nil {
+			return res, nil
+		}
+		log.WithError(err).Warnf("GetModelMetadata failed on connection %d/%d", i+1, len(clients))
+	}
+	promRequestsFailed.WithLabelValues("grpc").Inc()
+	return nil, fmt.Errorf("all %d connections failed for GetModelMetadata", len(clients))
 }
 
 func (server *proxyServiceServer) SessionRun(ctx context.Context, req *pb.SessionRunRequest) (*pb.SessionRunResponse, error) {
 	promRequestsTotal.WithLabelValues("grpc").Inc()
-	client, err := server.clientForSpec(req.GetModelSpec())
+	clients, err := server.clientForSpec(req.GetModelSpec())
 	if err != nil {
 		log.WithError(err).Error("Could not get grpc client")
 		promRequestsFailed.WithLabelValues("grpc").Inc()
 		return nil, err
 	}
-	service := pb.NewSessionServiceClient(client)
-	res, err := service.SessionRun(ctx, req)
-	return res, err
+	for i, client := range clients {
+		service := pb.NewSessionServiceClient(client)
+		res, err := service.SessionRun(ctx, req)
+		if err == nil {
+			return res, nil
+		}
+		log.WithError(err).Warnf("SessionRun failed on connection %d/%d", i+1, len(clients))
+	}
+	promRequestsFailed.WithLabelValues("grpc").Inc()
+	return nil, fmt.Errorf("all %d connections failed for SessionRun", len(clients))
 }
 
-func (server *proxyServiceServer) clientForSpec(modelSpec *pb.ModelSpec) (*grpc.ClientConn, error) {
+func (server *proxyServiceServer) clientForSpec(modelSpec *pb.ModelSpec) ([]*grpc.ClientConn, error) {
 	modelName := modelSpec.GetName()
 	modelVersion := strconv.FormatInt(modelSpec.GetVersion().GetValue(), 10)
 	return server.clientProvider(modelName, modelVersion)

--- a/pkg/tfservingproxy/tfservingproxy_test.go
+++ b/pkg/tfservingproxy/tfservingproxy_test.go
@@ -2,8 +2,10 @@ package tfservingproxy
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -79,7 +81,7 @@ func setupGrpcTestCache(proxyCallback func(modelName string, version string), mo
 		modelServer.Serve(lis)
 	}()
 
-	handlerMock := func(modelName string, version string) (*grpc.ClientConn, error) {
+	handlerMock := func(modelName string, version string) ([]*grpc.ClientConn, error) {
 		proxyCallback(modelName, version)
 		// No connection exists - swap to write lock and connect
 		conn, err := grpc.Dial(":8891",
@@ -87,7 +89,7 @@ func setupGrpcTestCache(proxyCallback func(modelName string, version string), mo
 		if err != nil {
 			log.Fatalf("Err: %v", err)
 		}
-		return conn, err
+		return []*grpc.ClientConn{conn}, err
 	}
 
 	grpcProxy := NewGrpcProxy(handlerMock, 1024*1024*16)
@@ -297,4 +299,140 @@ func (server *mockProxyServiceServer) MultiInference(ctx context.Context, req *p
 // GetModelMetadata - provides access to metadata for loaded models.
 func (server *mockProxyServiceServer) GetModelMetadata(ctx context.Context, req *pb.GetModelMetadataRequest) (*pb.GetModelMetadataResponse, error) {
 	return nil, nil
+}
+
+func TestGrpcProxyRetriesOnFailure(t *testing.T) {
+	// Start a real model server on a known port
+	modelServer := grpc.NewServer()
+	lis, err := net.Listen("tcp", ":8895")
+	if err != nil {
+		t.Fatalf("Failed to listen: %v", err)
+	}
+	modelServerCalled := false
+	server := mockProxyServiceServer{func(modelName string, modelVersion int64) {
+		modelServerCalled = true
+	}}
+	pb.RegisterPredictionServiceServer(modelServer, &server)
+	go modelServer.Serve(lis)
+
+	// clientProvider returns a dead connection first, then a good one
+	handlerMock := func(modelName string, version string) ([]*grpc.ClientConn, error) {
+		badConn, _ := grpc.Dial(":19999", grpc.WithInsecure()) // nothing listening
+		goodConn, _ := grpc.Dial(":8895", grpc.WithInsecure())
+		return []*grpc.ClientConn{badConn, goodConn}, nil
+	}
+
+	grpcProxy := NewGrpcProxy(handlerMock, 1024*1024*16)
+	go grpcProxy.Listen(8894)
+
+	// Send request — should fail on first conn, succeed on second
+	conn, err := grpc.Dial(":8894", grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("Failed to dial proxy: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewPredictionServiceClient(conn)
+	_, err = client.Classify(context.Background(), &pb.ClassificationRequest{
+		ModelSpec: &pb.ModelSpec{
+			Name:          "testmodel",
+			VersionChoice: &pb.ModelSpec_Version{Version: &wrappers.Int64Value{Value: 1}},
+		},
+		Input: &pb.Input{
+			Kind: &pb.Input_ExampleList{
+				ExampleList: &pb.ExampleList{
+					Examples: []*example.Example{{Features: &example.Features{}}},
+				},
+			},
+		},
+	})
+
+	grpcProxy.Close()
+	modelServer.GracefulStop()
+
+	if err != nil {
+		t.Errorf("Expected request to succeed via retry, got error: %v", err)
+	}
+	if !modelServerCalled {
+		t.Errorf("Model server was not called — retry did not reach good connection")
+	}
+}
+
+func TestGrpcProxyAllConnectionsFail(t *testing.T) {
+	// clientProvider returns only dead connections
+	handlerMock := func(modelName string, version string) ([]*grpc.ClientConn, error) {
+		badConn1, _ := grpc.Dial(":19998", grpc.WithInsecure())
+		badConn2, _ := grpc.Dial(":19997", grpc.WithInsecure())
+		return []*grpc.ClientConn{badConn1, badConn2}, nil
+	}
+
+	grpcProxy := NewGrpcProxy(handlerMock, 1024*1024*16)
+	go grpcProxy.Listen(8896)
+
+	conn, err := grpc.Dial(":8896", grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("Failed to dial proxy: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewPredictionServiceClient(conn)
+	_, err = client.Classify(context.Background(), &pb.ClassificationRequest{
+		ModelSpec: &pb.ModelSpec{
+			Name:          "testmodel",
+			VersionChoice: &pb.ModelSpec_Version{Version: &wrappers.Int64Value{Value: 1}},
+		},
+		Input: &pb.Input{
+			Kind: &pb.Input_ExampleList{
+				ExampleList: &pb.ExampleList{
+					Examples: []*example.Example{{Features: &example.Features{}}},
+				},
+			},
+		},
+	})
+
+	grpcProxy.Close()
+
+	if err == nil {
+		t.Errorf("Expected error when all connections fail, got nil")
+	}
+	if err != nil && !strings.Contains(err.Error(), "all 2 connections failed") {
+		t.Errorf("Expected 'all 2 connections failed' error, got: %v", err)
+	}
+}
+
+func TestGrpcProxyClientProviderError(t *testing.T) {
+	// clientProvider returns an error
+	handlerMock := func(modelName string, version string) ([]*grpc.ClientConn, error) {
+		return nil, fmt.Errorf("no nodes available")
+	}
+
+	grpcProxy := NewGrpcProxy(handlerMock, 1024*1024*16)
+	go grpcProxy.Listen(8898)
+
+	conn, err := grpc.Dial(":8898", grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("Failed to dial proxy: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewPredictionServiceClient(conn)
+	_, err = client.Classify(context.Background(), &pb.ClassificationRequest{
+		ModelSpec: &pb.ModelSpec{
+			Name:          "testmodel",
+			VersionChoice: &pb.ModelSpec_Version{Version: &wrappers.Int64Value{Value: 1}},
+		},
+		Input: &pb.Input{
+			Kind: &pb.Input_ExampleList{
+				ExampleList: &pb.ExampleList{
+					Examples: []*example.Example{{Features: &example.Features{}}},
+				},
+			},
+		},
+	})
+
+	grpcProxy.Close()
+
+	if err == nil {
+		t.Errorf("Expected error when clientProvider fails, got nil")
+	}
+	if err != nil && !strings.Contains(err.Error(), "no nodes available") {
+		t.Errorf("Expected 'no nodes available' error, got: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary

- **Stale connection eviction**: Check gRPC connection state before returning cached connection. If `TransientFailure` or `Shutdown`, close and replace with a fresh connection instead of routing requests through dead connections.
- **Hash ring retry**: Change `clientProvider` to return `[]*grpc.ClientConn` for all replica nodes. Each gRPC method iterates connections and returns on first success. Previously only one random replica was tried per request, even when multiple were available.
- **Smart retry**: Only retry on transient gRPC errors (`Unavailable`, `Internal`, `Unknown`, `DeadlineExceeded`). Application-level errors (`InvalidArgument`, `NotFound`, etc.) fail fast without retrying other replicas. Final error wraps the root cause for debuggability.
- **Extracted helpers**: `getOrCreateConnection` (with stale eviction and double-check locking) and `dialAndStore` for cleaner connection lifecycle management.
- **Graceful shutdown**: Handle `SIGTERM`/`SIGINT` signals for clean pod termination in Kubernetes. Marks health as unhealthy (stops traffic routing), waits 5s for k8s endpoint propagation, drains gRPC connections, deregisters from service discovery, and shuts down HTTP servers with a 15s timeout.
- **Error handling hardening**: gRPC `Listen` errors are now caught instead of silently discarded; `conn.Close()` errors are logged during eviction; replacement connections are state-checked in the double-check path; `restDirector` guards against empty node slices.
- **Metrics fix**: Fixed pre-existing bug where REST failure counter was incremented on both success and failure.
- **Retry tests**: Added tests for gRPC proxy retry behavior — successful fallback to second connection, all connections failing, and clientProvider error propagation.

## Why

When a cache node goes down, cached gRPC connections to dead pods are never cleaned up and continue receiving routed requests. Combined with only trying 1 of N available replicas per request, this causes unnecessary failures even when healthy replicas exist.

Additionally, the process had no signal handling — on pod termination (`SIGTERM`), in-flight requests were killed immediately and the node was never deregistered from service discovery, causing other nodes to continue routing traffic to it during the termination grace period.